### PR TITLE
chore: add explanation for consumer.recv().now_or_never() in examples

### DIFF
--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -68,7 +68,7 @@ async fn main() {
     let consumer: StreamConsumer<IamConsumerContext> = config.create_with_context(context).unwrap();
 
     // Uncomment the following code to get the partition list and assign the consumer to the partitions.
-    // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token 
+    // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token
     // before calling `consumer.fetch_metadata()`.
     // See https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a988395722598f63396d7a1bedb22adaf
     // for details.

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -68,8 +68,9 @@ async fn main() {
     let consumer: StreamConsumer<IamConsumerContext> = config.create_with_context(context).unwrap();
 
     // Uncomment the following code to get the partition list and assign the consumer to the partitions.
+    //
     // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token
-    // before calling `consumer.fetch_metadata()`.
+    // before calling `consumer.fetch_metadata()` here.
     //
     // > Note that before any SASL/OAUTHBEARER broker connection can succeed the application must call rd_kafka_oauthbearer_set_token()
     // > once – either directly or, more typically, by invoking either rd_kafka_poll(), rd_kafka_consumer_poll(), rd_kafka_queue_poll(),

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -67,6 +67,12 @@ async fn main() {
 
     let consumer: StreamConsumer<IamConsumerContext> = config.create_with_context(context).unwrap();
 
+    // Uncomment the following code to get the partition list and assign the consumer to the partitions.
+    // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token 
+    // before calling `consumer.fetch_metadata()`.
+    // See https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a988395722598f63396d7a1bedb22adaf
+    // for details.
+    //
     // assert!(consumer.recv().now_or_never().is_none());
     // let partition_list = {
     //     let mut list = TopicPartitionList::new();

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -70,6 +70,10 @@ async fn main() {
     // Uncomment the following code to get the partition list and assign the consumer to the partitions.
     // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token
     // before calling `consumer.fetch_metadata()`.
+    //
+    // > Note that before any SASL/OAUTHBEARER broker connection can succeed the application must call rd_kafka_oauthbearer_set_token()
+    // > once – either directly or, more typically, by invoking either rd_kafka_poll(), rd_kafka_consumer_poll(), rd_kafka_queue_poll(),
+    // > etc, in order to cause retrieval of an initial token to occur.
     // See https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a988395722598f63396d7a1bedb22adaf
     // for details.
     //

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -67,7 +67,7 @@ async fn main() {
 
     let consumer: StreamConsumer<IamConsumerContext> = config.create_with_context(context).unwrap();
 
-    // Uncomment the following code to get the partition list and assign the consumer to the partitions.
+    // Uncomment the following code to get the partition list and assign the to the consumer.
     //
     // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token
     // before calling `consumer.fetch_metadata()` here.

--- a/examples/consumer.rs
+++ b/examples/consumer.rs
@@ -67,7 +67,7 @@ async fn main() {
 
     let consumer: StreamConsumer<IamConsumerContext> = config.create_with_context(context).unwrap();
 
-    // Uncomment the following code to get the partition list and assign the to the consumer.
+    // Uncomment the following code to get the partition list and assign the partitions to the consumer.
     //
     // Please note that it's necessary to call `consumer.recv().now_or_never()` to refresh the OAUTHBEARER token
     // before calling `consumer.fetch_metadata()` here.


### PR DESCRIPTION
This is needed to trigger a `rd_kafka_oauthbearer_set_token()`. See more details in the code comments.

close #3 