### PR TITLE
feat: Factor credential expiration into MSK token TTL

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,8 @@ async fn construct_auth_token(
         SignerError::ConstructAuthToken(format!("failed to build request for signing: {e}"))
     })?;
 
-    sign_url(&mut url, region, credentials).map_err(|e| {
+    let ttl_secs = compute_ttl_secs(&credentials);
+    sign_url(&mut url, region, credentials, ttl_secs).map_err(|e| {
         SignerError::ConstructAuthToken(format!("failed to sign request with aws sig v4: {e}"))
     })?;
 
@@ -172,8 +173,28 @@ fn build_url(endpoint_url: &str) -> Result<Url, String> {
     Ok(url)
 }
 
+/// Computes TTL in seconds for the presigned URL, factoring in credential expiration
+/// so that the MSK token does not outlive the credentials (e.g. from AssumeRole).
+fn compute_ttl_secs(credentials: &Credentials) -> u64 {
+    let max_secs = DEFAULT_EXPIRY_SECONDS as u64;
+    match credentials.expiry() {
+        Some(exp) => {
+            let now = SystemTime::now();
+            let remaining = exp.duration_since(now).unwrap_or(Duration::ZERO);
+            let remaining_secs = remaining.as_secs();
+            remaining_secs.min(max_secs).max(1)
+        }
+        None => max_secs,
+    }
+}
+
 // Sign url with aws sig v4.
-fn sign_url(url: &mut Url, region: Region, credentials: Credentials) -> Result<(), String> {
+fn sign_url(
+    url: &mut Url,
+    region: Region,
+    credentials: Credentials,
+    expires_in_secs: u64,
+) -> Result<(), String> {
     use aws_sigv4::http_request::{
         sign, SignableBody, SignableRequest, SignatureLocation, SigningSettings,
     };
@@ -181,7 +202,7 @@ fn sign_url(url: &mut Url, region: Region, credentials: Credentials) -> Result<(
 
     let mut signing_settings = SigningSettings::default();
     signing_settings.signature_location = SignatureLocation::QueryParams;
-    signing_settings.expires_in = Some(Duration::from_secs(DEFAULT_EXPIRY_SECONDS as u64));
+    signing_settings.expires_in = Some(Duration::from_secs(expires_in_secs));
     let identity = credentials.into();
     let signing_params = v4::SigningParams::builder()
         .identity(&identity)
@@ -212,17 +233,24 @@ fn sign_url(url: &mut Url, region: Region, credentials: Credentials) -> Result<(
 
 // Parses the URL and gets the expiration time in millis associated with the signed url
 fn get_expiration_time_ms(signed_url: &Url) -> Result<i64, String> {
-    let (_name, value) = &signed_url
+    let date_value = signed_url
         .query_pairs()
         .find(|(name, _value)| name == "X-Amz-Date")
-        .unwrap_or_else(|| ("".into(), "".into()));
+        .map(|(_, v)| v.to_string())
+        .ok_or("missing 'X-Amz-Date' in signed url")?;
 
-    let date_time = NaiveDateTime::parse_from_str(value, "%Y%m%dT%H%M%SZ")
-        .map_err(|_e| format!("failed to parse 'X-Amz-Date' param {value} from signed url"))?;
+    let date_time = NaiveDateTime::parse_from_str(&date_value, "%Y%m%dT%H%M%SZ")
+        .map_err(|_e| format!("failed to parse 'X-Amz-Date' param {date_value} from signed url"))?;
 
     let signing_time_ms = date_time.and_utc().timestamp_millis();
 
-    Ok(signing_time_ms + DEFAULT_EXPIRY_SECONDS * 1000)
+    let expires_secs: i64 = signed_url
+        .query_pairs()
+        .find(|(name, _value)| name == "X-Amz-Expires")
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(DEFAULT_EXPIRY_SECONDS);
+
+    Ok(signing_time_ms + expires_secs * 1000)
 }
 
 // Base64 encode with raw url encoding.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,6 @@
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use chrono::Utc;
-use std::{borrow::Cow, collections::HashMap, env};
+use std::{borrow::Cow, collections::HashMap, env, time::Duration as StdDuration, time::SystemTime};
 
 use super::*;
 
@@ -82,7 +82,37 @@ async fn test_generate_auth_token_with_credentials_provider() {
     verify_auth_token(token, expiry_ms, &mock_creds);
 }
 
+/// When credentials expire soon (e.g. from AssumeRole), the MSK token TTL must not exceed
+/// credential lifetime so the token is not used with expired credentials.
+#[tokio::test]
+async fn test_auth_token_ttl_respects_credential_expiration() {
+    let ttl_secs = 10i64;
+    let expires_at = SystemTime::now() + StdDuration::from_secs(ttl_secs as u64);
+    let expiring_creds = Credentials::builder()
+        .access_key_id("EXPIRING-ACCESS-KEY")
+        .secret_access_key("EXPIRING-SECRET-KEY")
+        .session_token("EXPIRING-SESSION-TOKEN")
+        .expiry(expires_at)
+        .provider_name("test")
+        .build();
+
+    let (token, expiry_ms) = construct_auth_token(TEST_REGION, expiring_creds.clone())
+        .await
+        .unwrap();
+
+    verify_auth_token_with_expected_ttl(token, expiry_ms, &expiring_creds, Some(ttl_secs));
+}
+
 fn verify_auth_token(token: String, expiry_ms: i64, cred: &Credentials) {
+    verify_auth_token_with_expected_ttl(token, expiry_ms, cred, None);
+}
+
+fn verify_auth_token_with_expected_ttl(
+    token: String,
+    expiry_ms: i64,
+    cred: &Credentials,
+    expected_ttl_secs: Option<i64>,
+) {
     assert_ne!(expiry_ms, 0);
 
     let decoded_signed_url_bytes = BASE64_URL_SAFE_NO_PAD.decode(token).unwrap();
@@ -103,7 +133,18 @@ fn verify_auth_token(token: String, expiry_ms: i64, cred: &Credentials) {
         params.get("X-Amz-Algorithm"),
         Some(&Cow::Borrowed("AWS4-HMAC-SHA256"))
     );
-    assert_eq!(params.get("X-Amz-Expires"), Some(&Cow::Borrowed("900")));
+    let ttl_in_url = params.get("X-Amz-Expires").unwrap().parse::<i64>().unwrap();
+    if let Some(expected) = expected_ttl_secs {
+        // Allow up to 1s tolerance (e.g. between creating expiry and signing)
+        assert!(
+            ttl_in_url <= expected && ttl_in_url >= (expected - 1).max(1),
+            "X-Amz-Expires should be at most {} and at least 1, got {}",
+            expected,
+            ttl_in_url
+        );
+    } else {
+        assert_eq!(params.get("X-Amz-Expires"), Some(&Cow::Borrowed("900")));
+    }
     assert_eq!(
         params.get("X-Amz-Security-Token").cloned(),
         cred.session_token().map(|token| Cow::Borrowed(token))


### PR DESCRIPTION
## Summary

Factors credential expiration into the MSK auth token’s TTL so tokens are not used after the underlying credentials have expired. Matches the behavior introduced in the JS library in https://github.com/aws/aws-msk-iam-sasl-signer-js/pull/30.

## Problem

When using temporary credentials (e.g. from AssumeRole, SSO, or env vars), the signer always issued tokens with a 15-minute (900s) presign expiry. If the credentials expired sooner (e.g. in 5 minutes), the token could still be considered valid for 15 minutes. After the credentials expired, using that token caused authentication failures.

## Solution

- **TTL:** If credentials have an expiry (`Credentials::expiry()`), set the presign TTL to `min(seconds_until_credential_expiry, 900)`, with a minimum of 1 second. If there is no expiry, keep using 900s.
- **Signing:** Pass this TTL into the presigner so `X-Amz-Expires` matches the chosen TTL.
- **Returned expiry:** Compute the returned expiration time from the signed URL’s `X-Amz-Expires` so it always matches the actual token lifetime.

## Behavior

| Credentials              | Token TTL        |
|--------------------------|------------------|
| No expiry (long-lived)   | 900s (unchanged) |
| Expire in 10 minutes     | 600s             |
| Expire in 5 minutes      | 300s             |
| Expire in 10 seconds     | 10s              |

## Testing

- New test `test_auth_token_ttl_respects_credential_expiration` uses credentials with a short expiry and asserts the token’s `X-Amz-Expires` and returned expiry reflect that TTL.
- Existing tests still pass (credentials without expiry continue to use 900s).